### PR TITLE
Load end_of_life JSON database from dynamic path

### DIFF
--- a/lib/end_of_life/ruby_version.rb
+++ b/lib/end_of_life/ruby_version.rb
@@ -1,10 +1,13 @@
+require 'rubygems'
 require_relative "ruby_version/parser"
 
 module EndOfLife
   class RubyVersion
     include Comparable
 
-    EOL = File.read("lib/end_of_life.json")
+    DB_PATH = File.join(File.dirname(__FILE__), "../end_of_life.json")
+
+    EOL = File.read(DB_PATH)
       .then { |json| JSON.parse(json, symbolize_names: true) }
       .filter { |version| Date.parse(version[:eol]) <= Date.today }
       .map { |version| Gem::Version.new(version[:latest]) }

--- a/lib/end_of_life/ruby_version.rb
+++ b/lib/end_of_life/ruby_version.rb
@@ -1,4 +1,4 @@
-require 'rubygems'
+require "rubygems"
 require_relative "ruby_version/parser"
 
 module EndOfLife

--- a/lib/end_of_life/ruby_version.rb
+++ b/lib/end_of_life/ruby_version.rb
@@ -5,7 +5,7 @@ module EndOfLife
   class RubyVersion
     include Comparable
 
-    DB_PATH = File.join(File.dirname(__FILE__), "../end_of_life.json")
+    DB_PATH = File.join(__dir__, "../end_of_life.json")
 
     EOL = File.read(DB_PATH)
       .then { |json| JSON.parse(json, symbolize_names: true) }


### PR DESCRIPTION
When installed on a fresh Ruby installation without the source code
cloned, the JSON file couldn't be found because it was looking at the
cwd of the running process instead of the Gem's lib directory path.

I wish that Rubygems had a way of exposing a Gem's installation
directory programatically, but I couldn't find it quickly. `Gem.datadir`
didn't do what I wanted! So, we'll do it like it's 2014...