### PR TITLE
Allow specifying the user used on the repository search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Allow specifying the user used on the repository search
+
+```sh
+$ end_of_life --user=matz # searches on matz's repositories
+```
+
 - Upgrade `octokit` to v4.22, which fixes [a Faraday warning], so we can remove
   the dependency on the `warning` gem.
 

--- a/lib/end_of_life.rb
+++ b/lib/end_of_life.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "octokit"
+require "optparse"
 require_relative "end_of_life/repository"
 require_relative "end_of_life/ruby_version"
 require_relative "end_of_life/terminal_helper"
@@ -14,17 +15,62 @@ module EndOfLife
     include TerminalHelper
 
     def call(argv)
-      fetch_repositories
+      parse_options(argv)
+        .then { |options| execute_command(options) }
+    end
+
+    private
+
+    def execute_command(options)
+      case options[:command]
+      when :help
+        puts options[:parser]
+      when :version
+        puts "end_of_life v#{EndOfLife::VERSION}"
+      when :print_error
+        puts error_msg(options[:error])
+        exit(-1)
+      else
+        check_eol_ruby_on_repositories(options)
+      end
+    end
+
+    def check_eol_ruby_on_repositories(options)
+      fetch_repositories(user: options[:user])
         .fmap { |repositories| filter_repositories_with_end_of_life(repositories) }
         .fmap { |repositories| print_diagnose_for(repositories) }
         .or { |error| puts "\n#{error_msg(error)}" }
     end
 
-    private
+    def parse_options(argv)
+      options = {}
 
-    def fetch_repositories
+      OptionParser.new do |opts|
+        options[:parser] = opts
+
+        opts.banner = "Usage: end_of_life [options]"
+
+        opts.on("-u NAME", "--user=NAME", "Sets the user used on the repository search") do |user|
+          options[:user] = user
+        end
+
+        opts.on("-v", "--version", "Displays end_of_life version") do
+          options[:command] = :version
+        end
+
+        opts.on("-h", "--help", "Displays this help") do
+          options[:command] = :help
+        end
+      end.parse!(argv)
+
+      options
+    rescue OptionParser::ParseError => e
+      {command: :print_error, error: e}
+    end
+
+    def fetch_repositories(user:)
       with_loading_spinner("Fetching repositories...") do |spinner|
-        result = Repository.fetch(language: "ruby")
+        result = Repository.fetch(language: "ruby", user: user)
 
         spinner.error if result.failure?
 

--- a/lib/end_of_life/repository.rb
+++ b/lib/end_of_life/repository.rb
@@ -5,7 +5,7 @@ module EndOfLife
     class << self
       include Dry::Monads[:result, :maybe]
 
-      def fetch(language:, user: nil)
+      def fetch(language:, user:)
         github_client.fmap do |github|
           user ||= github.user.login
           response = github.search_repositories("user:#{user} language:#{language}", per_page: 100)

--- a/spec/end_of_life/cli_spec.rb
+++ b/spec/end_of_life/cli_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe EndOfLife::CLI do
+  describe "#call" do
+    context "with version option" do
+      it "prints the version" do
+        cli = EndOfLife::CLI.new
+
+        expect { cli.call(["-v"]) }.to output("end_of_life v#{EndOfLife::VERSION}\n").to_stdout
+      end
+    end
+
+    context "with help option" do
+      it "prints the help banner" do
+        cli = EndOfLife::CLI.new
+
+        expect { cli.call(["-h"]) }.to output(/Usage: end_of_life \[options\]/).to_stdout
+      end
+    end
+
+    context "with invalid option" do
+      it "exits with error message" do
+        cli = EndOfLife::CLI.new
+
+        expect { cli.call(["--unknown-option"]) }
+          .to exit_with_code(-1)
+          .and output(/invalid option: --unknown-option/).to_stdout
+      end
+    end
+
+    private
+
+    def exit_with_code(code)
+      raise_error(SystemExit) { |error| expect(error.status).to eq(code) }
+    end
+  end
+end


### PR DESCRIPTION
Related: #5 

```sh
$ end_of_life --user=matz # searches on Matz's repositories
```